### PR TITLE
Avoid using bare varibles in install_packages.yml

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -3,7 +3,7 @@
   yum:
     name: "{{ item }}"
     state: present
-  with_items: rvm.required_packages
+  with_items: "{{ rvm.required_packages }}"
   sudo: true
   when: ansible_os_family == "RedHat"
 
@@ -12,5 +12,5 @@
     name: "{{ item }}"
     state: present
   sudo: true
-  with_items: rvm.required_packages
+  with_items: "{{ rvm.required_packages }}"
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
Ansible had a deprectation warning:

TASK [altermn.rvm : ensure necessary yum packages are installed] ***************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full 
variable syntax ('{{rvm.required_packages}}').

With this patch the warning is gone.
