### PR TITLE
Remove role 'version' line in metadata file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -32,4 +32,3 @@ galaxy_info:
   - development
 
 dependencies: []
-version: 0.1.0


### PR DESCRIPTION
Ansible complains about the role 'version' line and stops executing.

Removing the line lets ansible continue.

This commit fixes #9
